### PR TITLE
Fix sign-in state handling

### DIFF
--- a/parking-app-frontend/src/context/AuthContext.js
+++ b/parking-app-frontend/src/context/AuthContext.js
@@ -33,7 +33,15 @@ export const AuthProvider = ({ children }) => {
   const signIn = async (email, password) => {
     try {
       const response = await api.post('/auth/signin', { email, password });
-      const userData = response.data;
+      // The backend returns `{ user: { ... }, accessToken }`. Consolidate the
+      // response so screens can access user fields directly without drilling
+      // into `user`.
+      const userData = {
+        ...response.data.user,
+        role: response.data.user.isManager ? 'manager' : 'user',
+        accessToken: response.data.accessToken,
+      };
+
       setUser(userData);
       await AsyncStorage.setItem('@parkingapp:user', JSON.stringify(userData));
       api.defaults.headers.common['Authorization'] = `Bearer ${userData.accessToken}`;


### PR DESCRIPTION
## Summary
- store user object flattened from API response

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm test` in `parking-app-backend` *(fails: Missing script)*
- `npm test` in `parking-app-frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887e2a5a284832ab5bbabf4842c7b1f