### PR TITLE
Update Expo dependencies and drop web support

### DIFF
--- a/parking-app-frontend/README.md
+++ b/parking-app-frontend/README.md
@@ -33,7 +33,7 @@ Esta pasta contém o aplicativo móvel construído em React Native utilizando o 
    npm start
    ```
 
-   O Expo abrirá uma interface no navegador onde você pode rodar o app em um emulador ou em um dispositivo físico usando o aplicativo **Expo Go**.
+   Abra o aplicativo **Expo Go** em um emulador Android/iOS ou em um dispositivo físico para executar o app.
 
 ## Navegação
 

--- a/parking-app-frontend/package-lock.json
+++ b/parking-app-frontend/package-lock.json
@@ -13,12 +13,10 @@
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
         "axios": "^1.5.0",
-        "expo": "^50.0.0",
+        "expo": "~50.0.21",
         "expo-status-bar": "^1.8.0",
         "react": "^18.2.0",
-        "react-dom": "18.2.0",
-        "react-native": "^0.73.3",
-        "react-native-web": "~0.19.6"
+        "react-native": "^0.73.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5938,12 +5936,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-react-native-web": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.18.12.tgz",
-      "integrity": "sha512-4djr9G6fMdwQoD6LQ7hOKAm39+y12flWgovAqS1k5O8f42YQ3A1FFMyV5kKfetZuGhZO5BmNmOdRRZQ1TixtDw==",
-      "license": "MIT"
-    },
     "node_modules/babel-plugin-syntax-hermes-parser": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.28.1.tgz",
@@ -5982,7 +5974,6 @@
         "@babel/preset-env": "^7.20.0",
         "@babel/preset-react": "^7.22.15",
         "@react-native/babel-preset": "^0.73.18",
-        "babel-plugin-react-native-web": "~0.18.10",
         "react-refresh": "0.14.0"
       }
     },
@@ -12028,28 +12019,6 @@
         }
       }
     },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/react-freeze": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
@@ -12161,38 +12130,6 @@
         "react": "*",
         "react-native": "*"
       }
-    },
-    "node_modules/react-native-web": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.13.tgz",
-      "integrity": "sha512-etv3bN8rJglrRCp/uL4p7l8QvUNUC++QwDbdZ8CB7BvZiMvsxfFIRM1j04vxNldG3uo2puRd6OSWR3ibtmc29A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@react-native/normalize-colors": "^0.74.1",
-        "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
-        "memoize-one": "^6.0.0",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "styleq": "^0.1.3"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/react-native-web/node_modules/@react-native/normalize-colors": {
-      "version": "0.74.89",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.89.tgz",
-      "integrity": "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==",
-      "license": "MIT"
-    },
-    "node_modules/react-native-web/node_modules/memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
-      "license": "MIT"
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
       "version": "0.73.3",

--- a/parking-app-frontend/package.json
+++ b/parking-app-frontend/package.json
@@ -7,11 +7,10 @@
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web"
+    "ios": "expo start --ios"
   },
   "dependencies": {
-    "expo": "^50.0.0",
+    "expo": "~50.0.21",
     "expo-status-bar": "^1.8.0",
     "react": "^18.2.0",
     "react-native": "^0.73.3",
@@ -19,8 +18,6 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "@react-native-async-storage/async-storage": "^1.22.0",
-    "react-native-web": "~0.19.6",
-    "react-dom": "18.2.0",
     "@expo/metro-runtime": "~3.1.3"
   }
 }


### PR DESCRIPTION
## Summary
- update Expo version and remove web-related dependencies
- remove web start script
- update instructions for running on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688937e51238832aa95d02887c301544